### PR TITLE
Fixed potential exception thrown in multi-episode pattern matching

### DIFF
--- a/MediaBrowser.Naming.Tests/TV/EpisodeNumberWithoutSeasonTests.cs
+++ b/MediaBrowser.Naming.Tests/TV/EpisodeNumberWithoutSeasonTests.cs
@@ -17,62 +17,80 @@ namespace MediaBrowser.Naming.Tests.TV
         [TestMethod]
         public void TestEpisodeNumberWithoutSeason2()
         {
-            Assert.AreEqual(02, GetEpisodeNumberFromFile(@"The Simpsons\The Simpsons - 02 - Ep Name.avi"));
+            Assert.AreEqual(2, GetEpisodeNumberFromFile(@"The Simpsons\The Simpsons - 02 - Ep Name.avi"));
         }
 
         [TestMethod]
         public void TestEpisodeNumberWithoutSeason3()
         {
-            Assert.AreEqual(02, GetEpisodeNumberFromFile(@"The Simpsons\02.avi"));
+            Assert.AreEqual(2, GetEpisodeNumberFromFile(@"The Simpsons\02.avi"));
         }
 
         [TestMethod]
         public void TestEpisodeNumberWithoutSeason4()
         {
-            Assert.AreEqual(02, GetEpisodeNumberFromFile(@"The Simpsons\02 - Ep Name.avi"));
+            Assert.AreEqual(2, GetEpisodeNumberFromFile(@"The Simpsons\02 - Ep Name.avi"));
         }
 
         [TestMethod]
         public void TestEpisodeNumberWithoutSeason5()
         {
-            Assert.AreEqual(02, GetEpisodeNumberFromFile(@"The Simpsons\02-Ep Name.avi"));
+            Assert.AreEqual(2, GetEpisodeNumberFromFile(@"The Simpsons\02-Ep Name.avi"));
         }
 
         [TestMethod]
         public void TestEpisodeNumberWithoutSeason6()
         {
-            Assert.AreEqual(02, GetEpisodeNumberFromFile(@"The Simpsons\02.EpName.avi"));
+            Assert.AreEqual(2, GetEpisodeNumberFromFile(@"The Simpsons\02.EpName.avi"));
         }
 
         [TestMethod]
         public void TestEpisodeNumberWithoutSeason7()
         {
-            Assert.AreEqual(02, GetEpisodeNumberFromFile(@"The Simpsons\The Simpsons - 02.avi"));
+            Assert.AreEqual(2, GetEpisodeNumberFromFile(@"The Simpsons\The Simpsons - 02.avi"));
         }
 
         [TestMethod]
         public void TestEpisodeNumberWithoutSeason8()
         {
-            Assert.AreEqual(02, GetEpisodeNumberFromFile(@"The Simpsons\The Simpsons - 02 Ep Name.avi"));
+            Assert.AreEqual(2, GetEpisodeNumberFromFile(@"The Simpsons\The Simpsons - 02 Ep Name.avi"));
         }
 
         [TestMethod]
         public void TestEpisodeNumberWithoutSeason9()
         {
-            Assert.AreEqual(02, GetEpisodeNumberFromFile(@"The Simpsons\The Simpsons 5 - 02 - Ep Name.avi"));
+            Assert.AreEqual(2, GetEpisodeNumberFromFile(@"The Simpsons\The Simpsons 5 - 02 - Ep Name.avi"));
         }
 
         [TestMethod]
         public void TestEpisodeNumberWithoutSeason10()
         {
-            Assert.AreEqual(02, GetEpisodeNumberFromFile(@"The Simpsons\The Simpsons 5 - 02 Ep Name.avi"));
+            Assert.AreEqual(2, GetEpisodeNumberFromFile(@"The Simpsons\The Simpsons 5 - 02 Ep Name.avi"));
         }
 
         [TestMethod]
         public void TestEpisodeNumberWithoutSeason11()
         {
-            Assert.AreEqual(07, GetEpisodeNumberFromFile(@"Seinfeld\Seinfeld 0807 The Checks.avi"));
-            Assert.AreEqual(08, GetSeasonNumberFromFile(@"Seinfeld\Seinfeld 0807 The Checks.avi"));
+            Assert.AreEqual(7, GetEpisodeNumberFromFile(@"Seinfeld\Seinfeld 0807 The Checks.avi"));
+            Assert.AreEqual(8, GetSeasonNumberFromFile(@"Seinfeld\Seinfeld 0807 The Checks.avi"));
+        }
+
+        [TestMethod]
+        public void TestEpisodeNumberWithoutSeason12()
+        {
+            Assert.AreEqual(7, GetEpisodeNumberFromFile(@"GJ Club (2013)\GJ Club - 07.mkv"));
+        }
+
+        [TestMethod]
+        public void TestEpisodeNumberWithoutSeason13()
+        {
+            Assert.AreEqual(13, GetEpisodeNumberFromFile(@"Case Closed (1996-2007)\Case Closed - 13.mkv"));
+        }
+
+        [TestMethod]
+        public void TestEpisodeNumberWithoutSeason14()
+        {
+            Assert.AreEqual(317, GetEpisodeNumberFromFile(@"Case Closed (1996-2007)\Case Closed - 317.mkv"));
         }
 
         private int? GetEpisodeNumberFromFile(string path)

--- a/MediaBrowser.Naming/TV/EpisodePathParser.cs
+++ b/MediaBrowser.Naming/TV/EpisodePathParser.cs
@@ -20,6 +20,12 @@ namespace MediaBrowser.Naming.TV
 
         public EpisodePathParserResult Parse(string path, bool isFolder, bool fillExtendedInfo = true)
         {
+            // Added to be able to use regex patterns which require a file extension.
+            // There were no failed tests without this block, but to be safe, we can keep it until
+            // the regex which require file extensions are modified so that they don't need them.
+            if (isFolder)
+                path += ".mp4";
+
             var query = from expression in _options.EpisodeExpressions
                         select Parse(path, expression);
             EpisodePathParserResult result = query.FirstOrDefault(r => r.Success);
@@ -115,13 +121,25 @@ namespace MediaBrowser.Naming.TV
                     {
                         result.SeasonNumber = num;
                     }
-
                     if (int.TryParse(match.Groups[2].Value, NumberStyles.Any, CultureInfo.InvariantCulture, out num))
                     {
                         result.EpisodeNumber = num;
                     }
+
                     result.Success = result.EpisodeNumber.HasValue;
                 }
+
+                // Invalidate match when the season is 200 through 1927 or above 2500
+                // because it is an error unless the TV show is intentionally using false season numbers.
+                // It avoids erroneous parsing of something like "Series Special (1920x1080).mkv" as being season 1920 episode 1080.
+                if (result.SeasonNumber >= 200 && result.SeasonNumber < 1928 || result.SeasonNumber > 2500)
+                    result.Success = false;
+
+                // Invalidate match when the season is greater than 1 and the episode is greater than 365
+                // because it is an error unless the TV show is intentionally using false episode numbers.
+                // It avoids erroneous parsing of something like "Series (2001-2002)\Episode 31.mp4" as being season 2001 episode 2002.
+                if (result.SeasonNumber > 1 && result.EpisodeNumber > 365)
+                    result.Success = false;
 
                 result.IsByDate = expression.IsByDate;
             }


### PR DESCRIPTION
I discovered this when I was examining the code and debugging tests. If you examine the code, you can see where the Substring function might fail.

Fixed an issue where exception is thrown if multi-episode ending number is matched at the end of a path string.
Removed a conditional operator which is always true.
Removed a fix to get a multi-episode directory path to work as it's no longer necessary.
Changed a line using LINQ functions to use LINQ syntax. It helps with debugging.
