### PR TITLE
Updated stack resolver for mixed files in a folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,4 @@ pip-log.txt
 #Mr Developer
 .mr.developer.cfg
 /.vs/Emby.Naming/v15/sqlite3
+/.vs/Emby.Naming/v15/Server/sqlite3

--- a/Emby.Naming.Tests/AudioBook/AudioBookListResolverTests.cs
+++ b/Emby.Naming.Tests/AudioBook/AudioBookListResolverTests.cs
@@ -292,6 +292,39 @@ namespace Emby.Naming.Tests.AudioBook
             Assert.AreEqual("Tides of Darkness", result[0].Name);
         }
 
+        [TestMethod]
+        // Test case provided by Luke, with mixed files in same folder
+        public void TestListResolver10()
+        {
+            var files = new[]
+            {
+                @"\\audiobooks\book\01 Come Together.m4a", // Book 1
+                @"\\audiobooks\book\01 Radioactive.m4a",   // Book 1
+                @"\\audiobooks\book\1-03 Pictures Of You (Live Detroit Version).mp3", // Book 2
+                @"\\audiobooks\book\02 Tiptoe.m4a",        // Book 1
+                @"\\audiobooks\book\08 Mother.wma",        // Book 3
+                @"\\audiobooks\book\24bit flac.flac",      // Book 4
+                @"\\audiobooks\book\Bad Voltage 2x19.ogg", // Book 5
+                @"\\audiobooks\book\mp2 test file.mp2",    // Book 6
+                @"\\audiobooks\book\Telegraph Road.ogg",   // Book 7
+            };
+            var resolver = GetResolver();
+            var result = resolver.Resolve(files.Select(i => new FileSystemMetadata
+            {
+                IsDirectory = false,
+                FullName = i
+
+            }).ToList()).ToList();
+
+            Assert.AreEqual(7, result.Count);
+            Assert.AreEqual(3, result[0].Files.Count);
+            Assert.AreEqual(null, result[0].Files[0].PartNumber);
+            Assert.AreEqual(1, result[0].Files[0].ChapterNumber);
+            Assert.AreEqual(19, result[4].Files[0].PartNumber);
+            Assert.AreEqual(2, result[4].Files[0].ChapterNumber);
+            Assert.AreEqual("book", result[0].Name);
+        }
+
         private AudioBookListResolver GetResolver()
         {
             var options = new ExtendedNamingOptions();

--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -503,14 +503,14 @@ namespace Emby.Naming.Common
                 @"ch(?:apter)?[\s_-]?(?<chapter>\d+)",
                 // Detect specified parts, like Part 02
                 @"p(?:ar)?t[\s_-]?(?<part>\d+)",
-                // Chapter is often beginning of filename
-                @"^(?<chapter>\d+)",
-                // Part if often ending of filename
-                @"(?<part>\d+)$",
                 // Sometimes named as 0001_005 (chapter_part)
                 @"(?<chapter>\d+)_(?<part>\d+)",
+                @"(?<chapter>\d+)\-(?<part>\d+)",
+                @"(?<chapter>\d+)x(?<part>\d+)",
                 // Some audiobooks are ripped from cd's, and will be named by disk number.
-                @"dis(?:c|k)[\s_-]?(?<chapter>\d+)"
+                @"dis(?:c|k)[\s_-]?(?<chapter>\d+)",
+                // Chapter is often beginning of filename. Part if often ending of filename
+                @"^(?<chapter>\d+)?.+?(?<part>\d+)?$"
             };
 
         }


### PR DESCRIPTION
As we've discussed, you wanted the resolver to be able to create multiple stacks from a single folder. This update should do just that.

Years in folder names are still not recognized/parsed, but it's quite late now, so I will implement that later. It's not crucial for implementation anyway, as it just helps metadata in some cases.